### PR TITLE
Update AdminShippifyOrdersController.php

### DIFF
--- a/shippify/controllers/admin/AdminShippifyOrdersController.php
+++ b/shippify/controllers/admin/AdminShippifyOrdersController.php
@@ -57,6 +57,11 @@ class AdminShippifyOrdersController extends ModuleAdminController
         'class' => 'fixed-width-xs',
         'filter_key' => 'ords!id_order'
       ),
+      'id_pdf' => array(
+      'title' => $this->l('ID PS'),
+      'align' => 'text-center',
+      'class' => 'fixed-width-xs'
+      ),     
       'task_id' => array(
         'title' => $this->l('Task ID')
       ),
@@ -107,6 +112,11 @@ class AdminShippifyOrdersController extends ModuleAdminController
         'filter_type' => 'int',
         'order_key' => 'osname'
       ),
+			'id_carrier' => array(
+				'title' => $this->l('Carrier'),
+				'align' => 'left',
+				'filter_key' => 'transporte!name',							
+				),      
       'date_add' => array(
         'title' => $this->l('Date'),
         'align' => 'text-right',


### PR DESCRIPTION
Se agregan dos campos al listado: El Identificador "numérico" del Pedido de Prestashop  (que es mas fácil de visualizar ya que es el que usa prestashop también en su propio listado de pedidos) y el nombre del transportista escogido en el pedido (a fin de poder decidir si se envía o no ese pedido a Shippfy.